### PR TITLE
[Feat/SSR-109] Add : monitor 기능 추가

### DIFF
--- a/apps/account/src/account.server.js
+++ b/apps/account/src/account.server.js
@@ -6,6 +6,9 @@ import PubSubManager from '@peekaboo-ssr/classes/PubSubManager';
 import G2SEventHandler from '@peekaboo-ssr/events/G2SEvent';
 import { handlers } from './handlers/index.js';
 import cluster from 'cluster';
+import express from 'express';
+import client from 'prom-client';
+import os from 'os';
 
 class AccountServer extends TcpServer {
   constructor() {
@@ -30,6 +33,71 @@ class AccountServer extends TcpServer {
         console.log('Distributor Notification: ', data);
       },
     );
+
+    const app = express();
+    const register = new client.Registry();
+
+    // 서비스 설정
+    const serviceName = 'account'; // 현재 서비스 이름
+    const PORT = Number(config.account.port) + 2000; // Prometheus HTTP 포트
+
+    // 디폴트 레이블 등록
+    register.setDefaultLabels({
+      service: serviceName, // 서비스 이름 레이블
+    });
+
+    // 기본 메트릭 수집
+    client.collectDefaultMetrics({ register });
+
+    // CPU 사용률 계산
+    const cpuUsageGauge = new client.Gauge({
+      name: 'server_cpu_usage_percent',
+      help: 'Current CPU usage percentage',
+      collect() {
+        const cpus = os.cpus();
+        const totalIdle = cpus.reduce((acc, cpu) => acc + cpu.times.idle, 0);
+        const totalTick = cpus.reduce((acc, cpu) => {
+          return acc + Object.values(cpu.times).reduce((sum, t) => sum + t, 0);
+        }, 0);
+
+        const idleDiff = totalIdle - (cpuUsageGauge.lastIdle || 0);
+        const totalDiff = totalTick - (cpuUsageGauge.lastTick || 0);
+
+        cpuUsageGauge.lastIdle = totalIdle;
+        cpuUsageGauge.lastTick = totalTick;
+
+        if (totalDiff > 0) {
+          const usagePercent = ((1 - idleDiff / totalDiff) * 100).toFixed(2);
+          cpuUsageGauge.set(Number(usagePercent));
+        }
+      },
+    });
+    register.registerMetric(cpuUsageGauge);
+
+    // 메모리 사용량 계산
+    const memoryUsageGauge = new client.Gauge({
+      name: 'server_memory_usage_mb',
+      help: 'Current memory usage in MB',
+      collect() {
+        const memoryUsage = process.memoryUsage();
+        memoryUsageGauge.set(Math.round(memoryUsage.rss / 1024 / 1024)); // MB 단위
+      },
+    });
+    register.registerMetric(memoryUsageGauge);
+
+    // /metrics 엔드포인트
+    app.get('/metrics', async (req, res) => {
+      console.log(`[Account] Metric Request`);
+      res.setHeader('Content-Type', register.contentType);
+      res.end(await register.metrics());
+    });
+
+    // HTTP 서버 실행
+    app.listen(PORT, () => {
+      console.log(
+        `[Account] prometheus metrics server for ${serviceName} running on port ${PORT}`,
+      );
+    });
   }
 }
 

--- a/apps/distributor/src/distributor.server.js
+++ b/apps/distributor/src/distributor.server.js
@@ -4,6 +4,8 @@ import config from '@peekaboo-ssr/config/distributor';
 import S2DEventHandler from './events/onS2D.event.js';
 import { handlers } from './handlers/index.js';
 import cluster from 'cluster';
+import express from 'express';
+import { serviceMap } from './source/connection.source.js';
 
 class Distributor extends TcpServer {
   constructor() {
@@ -14,6 +16,36 @@ class Distributor extends TcpServer {
       new S2DEventHandler(),
     );
     this.handlers = handlers;
+
+    const prometheusApp = express();
+    const PORT = Number(config.distributor.port) + 2000;
+
+    prometheusApp.get('/prometheus/targets', (req, res) => {
+      console.log(`[Distributor] prometheus targets request`);
+      const targets = [];
+
+      for (const [key, value] of Object.entries(serviceMap.microservices)) {
+        const serviceKey =
+          '127.0.0.1:' + (Number(value.info.port) + 2000).toString();
+        targets.push({
+          targets: [serviceKey],
+          labels: { job: value.info.name },
+        });
+      }
+
+      for (const [key, value] of Object.entries(serviceMap.dedicates)) {
+        targets.push({
+          targets: [key],
+          labels: { job: 'dedicated' },
+        });
+      }
+
+      res.json(targets);
+    });
+
+    prometheusApp.listen(PORT, () => {
+      console.log(`Distributor server Monitor Listening Start: ${PORT}`);
+    });
   }
 }
 

--- a/apps/game/master/src/game.server.js
+++ b/apps/game/master/src/game.server.js
@@ -1,12 +1,14 @@
 // 클러스터링을 위해 서비스가 마스터 서버 형태를 갖추어야 함.
 import cluster from 'cluster';
-import os from 'os';
 import TcpServer from '@peekaboo-ssr/classes/TcpServer';
 import config from '@peekaboo-ssr/config/game';
 import RedisManager from '@peekaboo-ssr/classes/RedisManager';
 import PubSubManager from '@peekaboo-ssr/classes/PubSubManager';
 import G2SEventHandler from '@peekaboo-ssr/events/G2SEvent';
 import { handlers } from './handlers/index.js';
+import express from 'express';
+import client from 'prom-client';
+import os from 'os';
 
 class GameServer extends TcpServer {
   constructor() {
@@ -31,6 +33,71 @@ class GameServer extends TcpServer {
         console.log('Distributor Notification: ', data);
       },
     );
+
+    const app = express();
+    const register = new client.Registry();
+
+    // 서비스 설정
+    const serviceName = 'game'; // 현재 서비스 이름
+    const PORT = Number(config.game.port) + 2000; // Prometheus HTTP 포트
+
+    // 디폴트 레이블 등록
+    register.setDefaultLabels({
+      service: serviceName, // 서비스 이름 레이블
+    });
+
+    // 기본 메트릭 수집
+    client.collectDefaultMetrics({ register });
+
+    // CPU 사용률 계산
+    const cpuUsageGauge = new client.Gauge({
+      name: 'server_cpu_usage_percent',
+      help: 'Current CPU usage percentage',
+      collect() {
+        const cpus = os.cpus();
+        const totalIdle = cpus.reduce((acc, cpu) => acc + cpu.times.idle, 0);
+        const totalTick = cpus.reduce((acc, cpu) => {
+          return acc + Object.values(cpu.times).reduce((sum, t) => sum + t, 0);
+        }, 0);
+
+        const idleDiff = totalIdle - (cpuUsageGauge.lastIdle || 0);
+        const totalDiff = totalTick - (cpuUsageGauge.lastTick || 0);
+
+        cpuUsageGauge.lastIdle = totalIdle;
+        cpuUsageGauge.lastTick = totalTick;
+
+        if (totalDiff > 0) {
+          const usagePercent = ((1 - idleDiff / totalDiff) * 100).toFixed(2);
+          cpuUsageGauge.set(Number(usagePercent));
+        }
+      },
+    });
+    register.registerMetric(cpuUsageGauge);
+
+    // 메모리 사용량 계산
+    const memoryUsageGauge = new client.Gauge({
+      name: 'server_memory_usage_mb',
+      help: 'Current memory usage in MB',
+      collect() {
+        const memoryUsage = process.memoryUsage();
+        memoryUsageGauge.set(Math.round(memoryUsage.rss / 1024 / 1024)); // MB 단위
+      },
+    });
+    register.registerMetric(memoryUsageGauge);
+
+    // /metrics 엔드포인트
+    app.get('/metrics', async (req, res) => {
+      console.log(`[Game] Metric Request`);
+      res.setHeader('Content-Type', register.contentType);
+      res.end(await register.metrics());
+    });
+
+    // HTTP 서버 실행
+    app.listen(PORT, () => {
+      console.log(
+        `[Game] prometheus metrics server for ${serviceName} running on port ${PORT}`,
+      );
+    });
   }
 }
 if (cluster.isPrimary) {

--- a/apps/gateway/src/gateway.server.js
+++ b/apps/gateway/src/gateway.server.js
@@ -7,6 +7,9 @@ import C2GEventHandler from './events/onC2G.event.js';
 import S2GEventHandler from './events/onS2G.event.js';
 import cluster from 'cluster';
 import { createRoutingTable } from './routes/create.routes.js';
+import express from 'express';
+import client from 'prom-client';
+import os from 'os';
 
 class GatewayServer extends TcpServer {
   constructor() {
@@ -49,6 +52,71 @@ class GatewayServer extends TcpServer {
         console.log('Distributor Notification: ', data);
       },
     );
+
+    const app = express();
+    const register = new client.Registry();
+
+    // 서비스 설정
+    const serviceName = 'gateway'; // 현재 서비스 이름
+    const PORT = Number(config.gateway.port) + 2000; // Prometheus HTTP 포트
+
+    // 디폴트 레이블 등록
+    register.setDefaultLabels({
+      service: serviceName, // 서비스 이름 레이블
+    });
+
+    // 기본 메트릭 수집
+    client.collectDefaultMetrics({ register });
+
+    // CPU 사용률 계산
+    const cpuUsageGauge = new client.Gauge({
+      name: 'server_cpu_usage_percent',
+      help: 'Current CPU usage percentage',
+      collect() {
+        const cpus = os.cpus();
+        const totalIdle = cpus.reduce((acc, cpu) => acc + cpu.times.idle, 0);
+        const totalTick = cpus.reduce((acc, cpu) => {
+          return acc + Object.values(cpu.times).reduce((sum, t) => sum + t, 0);
+        }, 0);
+
+        const idleDiff = totalIdle - (cpuUsageGauge.lastIdle || 0);
+        const totalDiff = totalTick - (cpuUsageGauge.lastTick || 0);
+
+        cpuUsageGauge.lastIdle = totalIdle;
+        cpuUsageGauge.lastTick = totalTick;
+
+        if (totalDiff > 0) {
+          const usagePercent = ((1 - idleDiff / totalDiff) * 100).toFixed(2);
+          cpuUsageGauge.set(Number(usagePercent));
+        }
+      },
+    });
+    register.registerMetric(cpuUsageGauge);
+
+    // 메모리 사용량 계산
+    const memoryUsageGauge = new client.Gauge({
+      name: 'server_memory_usage_mb',
+      help: 'Current memory usage in MB',
+      collect() {
+        const memoryUsage = process.memoryUsage();
+        memoryUsageGauge.set(Math.round(memoryUsage.rss / 1024 / 1024)); // MB 단위
+      },
+    });
+    register.registerMetric(memoryUsageGauge);
+
+    // /metrics 엔드포인트
+    app.get('/metrics', async (req, res) => {
+      console.log(`[Gateway] Metric Request`);
+      res.setHeader('Content-Type', register.contentType);
+      res.end(await register.metrics());
+    });
+
+    // HTTP 서버 실행
+    app.listen(PORT, () => {
+      console.log(
+        `[Gateway] prometheus metrics server for ${serviceName} running on port ${PORT}`,
+      );
+    });
   }
 
   // 각 서비스간 연결이 필요

--- a/apps/lobby/src/lobby.server.js
+++ b/apps/lobby/src/lobby.server.js
@@ -8,6 +8,9 @@ import { handlers } from './handlers/index.js';
 import { Room } from './classes/models/room.class.js';
 import { rooms } from '../room/room.js';
 import cluster from 'cluster';
+import express from 'express';
+import client from 'prom-client';
+import os from 'os';
 
 class LobbyServer extends TcpServer {
   constructor() {
@@ -29,6 +32,71 @@ class LobbyServer extends TcpServer {
     );
     rooms.push(new Room('tempId001', 'EXAMPLE'));
     rooms.push(new Room('tempId002', 'EXAMPLE'));
+
+    const app = express();
+    const register = new client.Registry();
+
+    // 서비스 설정
+    const serviceName = 'lobby'; // 현재 서비스 이름
+    const PORT = Number(config.lobby.port) + 2000; // Prometheus HTTP 포트
+
+    // 디폴트 레이블 등록
+    register.setDefaultLabels({
+      service: serviceName, // 서비스 이름 레이블
+    });
+
+    // 기본 메트릭 수집
+    client.collectDefaultMetrics({ register });
+
+    // CPU 사용률 계산
+    const cpuUsageGauge = new client.Gauge({
+      name: 'server_cpu_usage_percent',
+      help: 'Current CPU usage percentage',
+      collect() {
+        const cpus = os.cpus();
+        const totalIdle = cpus.reduce((acc, cpu) => acc + cpu.times.idle, 0);
+        const totalTick = cpus.reduce((acc, cpu) => {
+          return acc + Object.values(cpu.times).reduce((sum, t) => sum + t, 0);
+        }, 0);
+
+        const idleDiff = totalIdle - (cpuUsageGauge.lastIdle || 0);
+        const totalDiff = totalTick - (cpuUsageGauge.lastTick || 0);
+
+        cpuUsageGauge.lastIdle = totalIdle;
+        cpuUsageGauge.lastTick = totalTick;
+
+        if (totalDiff > 0) {
+          const usagePercent = ((1 - idleDiff / totalDiff) * 100).toFixed(2);
+          cpuUsageGauge.set(Number(usagePercent));
+        }
+      },
+    });
+    register.registerMetric(cpuUsageGauge);
+
+    // 메모리 사용량 계산
+    const memoryUsageGauge = new client.Gauge({
+      name: 'server_memory_usage_mb',
+      help: 'Current memory usage in MB',
+      collect() {
+        const memoryUsage = process.memoryUsage();
+        memoryUsageGauge.set(Math.round(memoryUsage.rss / 1024 / 1024)); // MB 단위
+      },
+    });
+    register.registerMetric(memoryUsageGauge);
+
+    // /metrics 엔드포인트
+    app.get('/metrics', async (req, res) => {
+      console.log(`[Lobby] Metric Request`);
+      res.setHeader('Content-Type', register.contentType);
+      res.end(await register.metrics());
+    });
+
+    // HTTP 서버 실행
+    app.listen(PORT, () => {
+      console.log(
+        `[Lobby] prometheus metrics server for ${serviceName} running on port ${PORT}`,
+      );
+    });
   }
 }
 if (cluster.isPrimary) {

--- a/apps/session/src/session.server.js
+++ b/apps/session/src/session.server.js
@@ -6,6 +6,9 @@ import PubSubManager from '@peekaboo-ssr/classes/PubSubManager';
 import G2SEventHandler from '@peekaboo-ssr/events/G2SEvent';
 import { handlers } from './handlers/index.js';
 import cluster from 'cluster';
+import express from 'express';
+import client from 'prom-client';
+import os from 'os';
 
 class SessionServer extends TcpServer {
   constructor() {
@@ -30,6 +33,71 @@ class SessionServer extends TcpServer {
         console.log('Distributor Notification: ', data);
       },
     );
+
+    const app = express();
+    const register = new client.Registry();
+
+    // 서비스 설정
+    const serviceName = 'session'; // 현재 서비스 이름
+    const PORT = Number(config.session.port) + 2000; // Prometheus HTTP 포트
+
+    // 디폴트 레이블 등록
+    register.setDefaultLabels({
+      service: serviceName, // 서비스 이름 레이블
+    });
+
+    // 기본 메트릭 수집
+    client.collectDefaultMetrics({ register });
+
+    // CPU 사용률 계산
+    const cpuUsageGauge = new client.Gauge({
+      name: 'server_cpu_usage_percent',
+      help: 'Current CPU usage percentage',
+      collect() {
+        const cpus = os.cpus();
+        const totalIdle = cpus.reduce((acc, cpu) => acc + cpu.times.idle, 0);
+        const totalTick = cpus.reduce((acc, cpu) => {
+          return acc + Object.values(cpu.times).reduce((sum, t) => sum + t, 0);
+        }, 0);
+
+        const idleDiff = totalIdle - (cpuUsageGauge.lastIdle || 0);
+        const totalDiff = totalTick - (cpuUsageGauge.lastTick || 0);
+
+        cpuUsageGauge.lastIdle = totalIdle;
+        cpuUsageGauge.lastTick = totalTick;
+
+        if (totalDiff > 0) {
+          const usagePercent = ((1 - idleDiff / totalDiff) * 100).toFixed(2);
+          cpuUsageGauge.set(Number(usagePercent));
+        }
+      },
+    });
+    register.registerMetric(cpuUsageGauge);
+
+    // 메모리 사용량 계산
+    const memoryUsageGauge = new client.Gauge({
+      name: 'server_memory_usage_mb',
+      help: 'Current memory usage in MB',
+      collect() {
+        const memoryUsage = process.memoryUsage();
+        memoryUsageGauge.set(Math.round(memoryUsage.rss / 1024 / 1024)); // MB 단위
+      },
+    });
+    register.registerMetric(memoryUsageGauge);
+
+    // /metrics 엔드포인트
+    app.get('/metrics', async (req, res) => {
+      console.log(`[Session] Metric Request`);
+      res.setHeader('Content-Type', register.contentType);
+      res.end(await register.metrics());
+    });
+
+    // HTTP 서버 실행
+    app.listen(PORT, () => {
+      console.log(
+        `[Session] prometheus metrics server for ${serviceName} running on port ${PORT}`,
+      );
+    });
   }
 }
 if (cluster.isPrimary) {


### PR DESCRIPTION
1. Monitoring 기능 추가
- prometheus 서버와 통신할 웹 서버를 서비스 서버마다 열도록 추가
- prometheus 서버와 모니터링할 데이터를 메트릭으로 교환
  - prometheus : localhost:9090에서 확인 가능
- grafana : prometheus로 얻은 메트릭을 시각화해주는 툴
  - localhost:3000 (id: admin)
  
2. 메트릭 대상 데이터
- CPU 사용률, 메모리 사용량
- 추후 추가 예정