### PR TITLE
update, fix: 플레이어 HP 동기화 요청 추가 및 프로토 수정

### DIFF
--- a/apps/game/dedicated/src/classes/models/game.class.js
+++ b/apps/game/dedicated/src/classes/models/game.class.js
@@ -295,12 +295,6 @@ class Game {
     // 위치 및 상태초기화
     this.users.forEach((user) => {
       user.character.position.updateClassPosition(startPosition);
-
-      // Q. 사망하고 다시 스폰된 플레이어 생명력을 통지할지??
-      // => lifeResponse() 모두 보내주도록 설정
-      if (user.character.state === CHARACTER_STATE.DIED) {
-        user.character.life = 1;
-      }
       user.character.state = CHARACTER_STATE.IDLE;
     });
   }

--- a/apps/game/dedicated/src/handlers/game/item/item.handler.js
+++ b/apps/game/dedicated/src/handlers/game/item/item.handler.js
@@ -111,6 +111,34 @@ export const itemUseRequestHandler = async (
   }
 };
 
+export const itemDisuseRequestHandler = async (
+  socket,
+  clientKey,
+  payload,
+  server,
+) => {
+  try {
+    const { itemId } = payload;
+
+    const user = getUserByClientKey(server.game.users, clientKey);
+    if (!user) {
+      throw new CustomError(errorCodesMap.USER_NOT_FOUND);
+    }
+
+    const item = server.game.getItem(itemId);
+
+    if (!item) {
+      throw new CustomError(errorCodesMap.ITEM_NOT_FOUND);
+    }
+
+    item.on = false;
+
+    itemDisuseNotification(server.game, user.id, itemId);
+  } catch (e) {
+    handleError(e);
+  }
+};
+
 export const itemDiscardRequestHandler = async (
   socket,
   clientKey,
@@ -148,34 +176,6 @@ export const itemDiscardRequestHandler = async (
     itemDiscardResponse(user.clientKey, server.game.socket, inventorySlot);
 
     itemDiscardNotification(server.game, user.id, itemId);
-  } catch (e) {
-    handleError(e);
-  }
-};
-
-export const itemDisuseRequestHandler = async (
-  socket,
-  clientKey,
-  payload,
-  server,
-) => {
-  try {
-    const { itemId } = payload;
-
-    const user = getUserByClientKey(server.game.users, clientKey);
-    if (!user) {
-      throw new CustomError(errorCodesMap.USER_NOT_FOUND);
-    }
-
-    const item = server.game.getItem(itemId);
-
-    if (!item) {
-      throw new CustomError(errorCodesMap.ITEM_NOT_FOUND);
-    }
-
-    item.on = false;
-
-    itemDisuseNotification(server.game, user.id, itemId);
   } catch (e) {
     handleError(e);
   }

--- a/apps/game/dedicated/src/handlers/game/player/life.handler.js
+++ b/apps/game/dedicated/src/handlers/game/player/life.handler.js
@@ -1,0 +1,36 @@
+import handleError from '@peekaboo-ssr/error/handleError';
+import { getUserByClientKey } from '../../../sessions/user.sessions';
+import CustomError from '@peekaboo-ssr/error/CustomError';
+import errorCodesMap from '@peekaboo-ssr/error/errorCodesMap';
+import { createPacketS2G } from '@peekaboo-ssr/utils/createPacket';
+import config from '@peekaboo-ssr/config/game';
+
+// 클라이언트에서 캐릭터가 생성될 때마다 보내는 패킷
+// HP 동기화를 위한 핸들러
+export const lifeUpdateHandler = (socket, clientKey, payload, server) => {
+  console.log('lifeUpdateHandler.....');
+  try {
+    const user = getUserByClientKey(server.game, clientKey);
+    if (!user) {
+      throw new CustomError(errorCodesMap.USER_NOT_FOUND);
+    }
+    if (user.character.state === CHARACTER_STATE.DIED) {
+      user.character.life = 1;
+    }
+
+    const lifePayload = {
+      life: user.character.life,
+      isAttacked: false,
+    };
+
+    const packet = createPacketS2G(
+      config.clientPacket.dedicated.PlayerLifeResponse,
+      clientKey,
+      lifePayload,
+    );
+
+    server.game.socket.write(packet);
+  } catch (e) {
+    handleError(e);
+  }
+};

--- a/apps/game/dedicated/src/handlers/game/player/player.handler.js
+++ b/apps/game/dedicated/src/handlers/game/player/player.handler.js
@@ -31,8 +31,6 @@ export const playerStateChangeRequestHandler = async (
 
       playerStateChangeNotification(server.game, payload);
 
-      // console.log(`player State : ${playerStateInfo.characterState}`);
-
       // 만약 player 한명이라도 탈출했다면 스테이지 종료한다.
       if (user.character.state === CHARACTER_STATE.EXIT) {
         await server.game.endStage();
@@ -78,6 +76,7 @@ export const playerAttackedRequestHandler = async (
 
     const lifePayload = {
       life: user.character.life,
+      isAttacked: true,
     };
 
     const packet = createPacketS2G(
@@ -99,10 +98,9 @@ export const playerAttackedRequestHandler = async (
     console.log('플레이어 상태 변경: ', playerStatePayload);
     playerStateChangeNotification(server.game, playerStatePayload);
 
-    // 만약 player가 죽었다면
-    // 아이템을 바닥에 뿌린다.
-    // 스테이지 종료를 검사한다.
+    // 만약 player가 죽었다면 아이템을 바닥에 뿌리고, 스테이지 종료를 검사한다.
     if (user.character.state === CHARACTER_STATE.DIED) {
+      // TODO: 테스트 필요
       // const length = user.character.inventory.slot.length;
 
       // for (let i = 0; i < length; i++) {

--- a/apps/game/dedicated/src/handlers/index.js
+++ b/apps/game/dedicated/src/handlers/index.js
@@ -25,6 +25,7 @@ import { itemPurchaseHandler } from './game/store/store.handler.js';
 import { connectedServiceNotificationHandler } from './service/connectService.handler.js';
 import { exitDedicatedHandler } from './service/exitDedicate.handler.js';
 import { joinDedicatedHandler } from './service/joinDedicate.handler.js';
+import { lifeUpdateHandler } from './game/player/life.handler.js';
 
 export const handlers = {
   client: {
@@ -109,6 +110,10 @@ export const handlers = {
     /*-------------------------권영현 작업--------------------------*/
     [config.clientPacket.dedicated.ItemPurchaseRequest]: {
       handler: itemPurchaseHandler,
+      protoType: 'common.GamePacket',
+    },
+    [config.clientPacket.dedicated.LifeUpdateRequest]: {
+      handler: lifeUpdateHandler,
       protoType: 'common.GamePacket',
     },
   },

--- a/client/client.proto
+++ b/client/client.proto
@@ -118,6 +118,7 @@ message RoomInfo {
   uint32 latency = 4;
 }
 
+
 message C2S_PlayerMoveRequest {
   PlayerMoveInfo playerMoveInfo = 1;
 }
@@ -172,8 +173,13 @@ message C2S_PlayerAttackedRequest {
   uint32 ghostId = 2;
 } 
 
+message C2S_LifeUpdateRequest {
+
+}
+
 message S2C_PlayerLifeResponse {
   uint32 life= 1;
+  bool isAttacked = 2;
 }
 
 message C2S_GhostSpecialStateRequest {
@@ -253,7 +259,7 @@ message C2S_ItemDisuseRequest {
 }
 
 message S2C_ItemDisuseNotification {
-  uint32 userId = 1;
+  string userId = 1;
   uint32 itemId  = 2;
 }
 
@@ -420,7 +426,7 @@ message S2C_JoinRoomNotification {
 
 message GamePacket {
   oneof payload {
-   C2S_PlayerMoveRequest playerMoveRequest = 1;
+    C2S_PlayerMoveRequest playerMoveRequest = 1;
     S2C_PlayerMoveNotification playerMoveNotification = 2;
     C2S_GhostMoveRequest ghostMoveRequest = 3;
     S2C_GhostMoveNotification ghostMoveNotification = 4;
@@ -435,6 +441,7 @@ message GamePacket {
 
     C2S_PlayerAttackedRequest playerAttackedRequest = 101;
     S2C_PlayerLifeResponse playerLifeResponse = 102;
+    C2S_LifeUpdateRequest lifeUpdateRequest = 103;
 
     C2S_GhostSpecialStateRequest ghostSpecialStateRequest = 201;
     S2C_GhostSpecialStateNotification ghostSpecialStateNotification = 202;

--- a/packages/common/protobufs/common/common.packet.proto
+++ b/packages/common/protobufs/common/common.packet.proto
@@ -21,6 +21,7 @@ message GamePacket {
 
     C2S_PlayerAttackedRequest playerAttackedRequest = 101;
     S2C_PlayerLifeResponse playerLifeResponse = 102;
+    C2S_LifeUpdateRequest lifeUpdateRequest = 103;
 
     C2S_GhostSpecialStateRequest ghostSpecialStateRequest = 201;
     S2C_GhostSpecialStateNotification ghostSpecialStateNotification = 202;

--- a/packages/common/protobufs/game/game.packet.proto
+++ b/packages/common/protobufs/game/game.packet.proto
@@ -59,8 +59,13 @@ message C2S_PlayerAttackedRequest {
   uint32 ghostId = 2;
 } 
 
+message C2S_LifeUpdateRequest {
+
+}
+
 message S2C_PlayerLifeResponse {
   uint32 life= 1;
+  bool isAttacked = 2;
 }
 
 message C2S_GhostSpecialStateRequest {
@@ -140,7 +145,7 @@ message C2S_ItemDisuseRequest {
 }
 
 message S2C_ItemDisuseNotification {
-  uint32 userId = 1;
+  string userId = 1;
   uint32 itemId  = 2;
 }
 

--- a/packages/modules/constants/packet/client.packet.js
+++ b/packages/modules/constants/packet/client.packet.js
@@ -39,6 +39,7 @@ const CLIENT_PACKET = {
     // 플레이어 : 100번대
     PlayerAttackedRequest: 101,
     PlayerLifeResponse: 102,
+    LifeUpdateRequest: 103,
 
     // 귀신 : 200번대
     GhostSpecialStateRequest: 201,

--- a/packages/modules/constants/protoNames/client.proto.js
+++ b/packages/modules/constants/protoNames/client.proto.js
@@ -41,6 +41,7 @@ const CLIENT_PACKET_MAPS = {
   // 플레이어 : 100번대
   [clientPacket.dedicated.PlayerAttackedRequest]: 'playerAttackedRequest',
   [clientPacket.dedicated.PlayerLifeResponse]: 'playerLifeResponse',
+  [clientPacket.dedicated.LifeUpdateRequest]: 'lifeUpdateRequest',
 
   // 귀신 : 200번대
   [clientPacket.dedicated.GhostSpecialStateRequest]: 'ghostSpecialStateRequest',


### PR DESCRIPTION
1. LifeUpdateRequest 패킷 추가, 클라에서 캐릭터를 생성할 때마다 서버에 저장된 HP를 동기화하기 위한 요청
2. LifeUpdateRequest 로직 구현
3. 아이템 disuse 에서 userId 필드값 string으로 변경