### PR TITLE
fix: 귀신 로테이션 값 동기화 정보 추가, 플레이어 lifeUpdate 수정

### DIFF
--- a/apps/game/dedicated/src/classes/models/ghost.class.js
+++ b/apps/game/dedicated/src/classes/models/ghost.class.js
@@ -6,7 +6,7 @@ class Ghost {
     this.id = id;
     this.ghostTypeId = ghostTypeId;
     this.position = new Position(position.x, position.y, position.z);
-    //this.rotation = new Rotation(rotation.x, rotation.y, rotation.z);
+    this.rotation = new Rotation(0, 0, 0);
     this.state = state;
   }
 

--- a/apps/game/dedicated/src/handlers/game/ghost/moveGhost.handler.js
+++ b/apps/game/dedicated/src/handlers/game/ghost/moveGhost.handler.js
@@ -16,15 +16,15 @@ export const moveGhostRequestHandler = (socket, clientKey, payload, server) => {
 
     // 해당 게임 세션에 고스트들의 정보 저장
     ghostMoveInfos.forEach((ghostMoveInfo) => {
-      const { ghostId, position } = ghostMoveInfo;
+      const { ghostId, position, rotation } = ghostMoveInfo;
 
       const ghost = server.game.getGhost(ghostId);
       if (!ghost) {
         console.error('해당 귀신 정보가 존재하지 않습니다.');
       } else {
         ghost.position.updatePosition(position.x, position.y, position.z);
+        ghost.rotation.updateRotation(rotation.x, rotation.y, rotation.z);
       }
-      // ghost.rotation.updateRotation(rotation.x, rotation.y, rotation.z);
     });
   } catch (e) {
     handleError(e);

--- a/apps/game/dedicated/src/handlers/game/player/life.handler.js
+++ b/apps/game/dedicated/src/handlers/game/player/life.handler.js
@@ -17,6 +17,7 @@ export const lifeUpdateHandler = (socket, clientKey, payload, server) => {
 
     if (user.character.state === CHARACTER_STATE.DIED) {
       user.character.life = 1;
+      user.character.state = CHARACTER_STATE.IDLE;
     }
 
     const lifePayload = {

--- a/apps/game/dedicated/src/notifications/ghost/ghost.notification.js
+++ b/apps/game/dedicated/src/notifications/ghost/ghost.notification.js
@@ -17,7 +17,7 @@ export const ghostsLocationNotification = (game) => {
     const ghostMoveInfo = {
       ghostId: ghost.id,
       position: ghost.position.getPosition(),
-      // rotation: ghost.rotation.getRotation(),
+      rotation: ghost.rotation.getRotation(),
     };
 
     return ghostMoveInfo;
@@ -26,6 +26,7 @@ export const ghostsLocationNotification = (game) => {
   const payload = {
     ghostMoveInfos,
   };
+  console.log('@@@@ ghost positions: ', payload);
 
   // 해당 게임 세션에 참여한 유저들에게 notification 보내주기
   game.users.forEach((user) => {

--- a/client/client.proto
+++ b/client/client.proto
@@ -92,6 +92,7 @@ message GhostInfo {
 message GhostMoveInfo {
   uint32 ghostId = 1;
   Position position = 2;
+  Rotation rotation = 3;
 }
 
 message GhostStateInfo {

--- a/packages/common/protobufs/game/game.data.proto
+++ b/packages/common/protobufs/game/game.data.proto
@@ -45,6 +45,7 @@ message GhostInfo {
 message GhostMoveInfo {
   uint32 ghostId = 1;
   Position position = 2;
+  Rotation rotation = 3;
 }
 
 message GhostStateInfo {


### PR DESCRIPTION
1. 귀신 동기화 로테이션도 하도록 수정
  - 클라이언트에서 Agent 사용하지 않도록 변경
2. 플레이어 lifeUpdateHandler 에서 DIED 였다면 체력 1로 만들고 IDLE로 변경하도록 함.
  - 2차 방어 (initStage() 를 하기 전에 올 수 있어서)