### PR TITLE
[Feat/refactor] Fix : 하트 아이템, 사망 패털티, 참가 로직 수정

### DIFF
--- a/apps/game/dedicated/src/assets/difficulty.json
+++ b/apps/game/dedicated/src/assets/difficulty.json
@@ -10,7 +10,8 @@
       "MaxGhostNumber": 3,
       "TimeLimit": 620,
       "MinSoulItemNumber": 10,
-      "MaxSoulItemNumber": 16
+      "MaxSoulItemNumber": 16,
+      "Penalty": 0
     },
     {
       "Id": 102,
@@ -20,7 +21,8 @@
       "MaxGhostNumber": 4,
       "TimeLimit": 620,
       "MinSoulItemNumber": 8,
-      "MaxSoulItemNumber": 13
+      "MaxSoulItemNumber": 13,
+      "Penalty": 10
     },
     {
       "Id": 103,
@@ -30,7 +32,8 @@
       "MaxGhostNumber": 4,
       "TimeLimit": 620,
       "MinSoulItemNumber": 7,
-      "MaxSoulItemNumber": 10
+      "MaxSoulItemNumber": 10,
+      "Penalty": 20
     }
   ]
 }

--- a/apps/game/dedicated/src/classes/managers/gameQueue.manager.js
+++ b/apps/game/dedicated/src/classes/managers/gameQueue.manager.js
@@ -106,11 +106,6 @@ class GameQueueManager {
 
       itemGetResponse(user.clientKey, this.game.socket, itemId, inventorySlot);
       itemGetNotification(this.game, itemId, user.id);
-
-      if (!this.game.ghostCSpawn && user.character.inventory.itemCount === 4) {
-        this.game.ghostCSpawn = true;
-        // ghostC 소환 요청 로직 추가
-      }
     } finally {
       await RedisManager.getClient().del(lockKey);
     }

--- a/apps/game/dedicated/src/constants/game.js
+++ b/apps/game/dedicated/src/constants/game.js
@@ -2,8 +2,6 @@ export const MAX_PLAYER = 4;
 
 export const MAX_PLAYER_HP = 3;
 
-export const MAX_GHOST_NUM = 5;
-
 export const INVITE_CODE_LENGTH = 10;
 
 export const MAX_DOOR_NUM = 30;

--- a/apps/game/dedicated/src/handlers/game/Extractor/extractor.handler.js
+++ b/apps/game/dedicated/src/handlers/game/Extractor/extractor.handler.js
@@ -50,48 +50,10 @@ export const extractorSoulHandler = async (
       server.game.removeItem(itemId);
       soulItems.push(item.id);
     });
+
     itemDeleteNotification(server.game, soulItems);
     server.game.soulCredit += soulValue;
     extractSoulNotification(server.game, server.game.soulCredit);
-
-    // 아이템 검증
-    // const item = server.game.getItem(itemId);
-    // if (!item) {
-    //   throw new CustomError(errorCodesMap.ITEM_NOT_FOUND);
-    // }
-
-    // // 인벤토리 검증
-    // // 유저의 인벤토리(Redis)에서 아이템 찾기
-    // const serverItemId = user.character.inventory.slot[inventorySlot - 1];
-
-    // if (!serverItemId) {
-    //   throw new CustomError(errorCodesMap.ITEM_NOT_FOUND);
-    // }
-
-    // // ------------------------- 로직 ------------------------------
-    // // TODO : 데이터 테이블에 명시된 소울 타입의 영혼 수치를 가져온다.
-    // // 테스트 용도로 모든 영혼의 가치를 10으로 고정했다.
-    // const soulValue = server.game.gameAssets.item.data.find(itemId);
-
-    // // 영혼의 가치만큼 유저의 EXP와 MONEY를 올려준다. (Response)
-    // // TODO : DB에도 반영 ********************************************
-    // user.exp += soulValue;
-
-    // // submission의 영혼 추출 현재 수치를 영혼의 가치만큼 올려준다. (Notification)
-    // server.game.currentSoulAmount += soulValue;
-
-    // // 유저의 인벤토리(Redis)에서 영혼 아이템을 삭제시켜준다.
-    // await removeItemRedis(user.id, inventorySlot);
-
-    // // 게임에서 해당 아이템(소울)을 삭제시킨다. (Notification)
-    // server.game.removeItem(itemId);
-
-    // // ---------------------- 패킷 송신 ----------------------------
-    // // 추출한 영혼 아이템 삭제 Notification
-    // //itemDeleteNotification(server.game, itemId);
-
-    // // 영혼 누적 추출량 Notification
-    // extractSoulNotification(server.game);
   } catch (e) {
     handleError(e);
   }

--- a/apps/game/dedicated/src/handlers/game/player/player.handler.js
+++ b/apps/game/dedicated/src/handlers/game/player/player.handler.js
@@ -47,10 +47,6 @@ export const playerStateChangeRequestHandler = async (
       // 만약 player 한명이라도 탈출했다면 스테이지 종료한다.
       if (user.character.state === CHARACTER_STATE.EXIT) {
         await server.game.endStage();
-        // if (.checkStageEnd()) {
-        //   // 스테이지 종료 조건이 만족했다면,
-
-        // }
       }
     }
   } catch (e) {
@@ -118,6 +114,7 @@ export const playerAttackedRequestHandler = async (
       // 스테이지 종료 조건을 확인하기 2중으로 체크하도록 함 : 윤수빈
       if (user.character.state === CHARACTER_STATE.DIED) {
         if (server.game.checkStageEnd()) {
+          server.game.isRemainingTimeOver = true;
           await server.game.endStage();
         }
       }

--- a/apps/game/dedicated/src/handlers/service/joinDedicate.handler.js
+++ b/apps/game/dedicated/src/handlers/service/joinDedicate.handler.js
@@ -3,12 +3,29 @@ import { createPacketS2S } from '@peekaboo-ssr/utils/createPacket';
 import config from '@peekaboo-ssr/config/game';
 import { sendJoinRoomResponse } from '../../response/room/room.response.js';
 import { joinRoomNotification } from '../../notifications/room/room.notification.js';
+import { SUBMISSION_DURATION } from '../../constants/game.js';
 
 export const joinDedicatedHandler = (server, payload) => {
   console.log('joinDedicated.....');
   const { clientKey, userId } = payload;
 
   try {
+    // 4인 초과라면 실패
+    if (server.game.users.length >= MAX_PLAYER) {
+      sendJoinRoomResponse(server.game, clientKey, false);
+      return;
+    }
+
+    // 게임이 준비 단계이고, 서브미션이 첫번째가 아닌 경우 실패
+    if (
+      server.game.state !== config.clientState.gameState.PREPARE &&
+      server.game.day !== SUBMISSION_DURATION &&
+      server.game.submissionId !== server.game.gameAssets.submission.data[0].Id
+    ) {
+      sendJoinRoomResponse(server.game, clientKey, false);
+      return;
+    }
+
     const user = new User(userId, clientKey);
     // 게임에 유저 등록
     server.game.addUser(user, false);


### PR DESCRIPTION
1. 하트 아이템 로직 추가
  - Response로 실패/성공 전달
  - lifeResponse로 +1된 life 전달
  - extractorSoulNotification로 soulCredit 동기화

2. 사망 패널티
  - difficulty 테이블에 penalty 추가
  - endStage()에서 패널티 적용

3. 참가 로직 수정
  - 최대 4인까지만 참가하도록 수정
  - (서브미션 : 첫단계 & Remaining Days : 2, State : PREPARE)일때만 참가하도록 수정